### PR TITLE
Fixed no-return warning in setMessageHandler

### DIFF
--- a/MQTTClient/src/MQTTClient.h
+++ b/MQTTClient/src/MQTTClient.h
@@ -837,7 +837,7 @@ int MQTT::Client<Network, Timer, MAX_MQTT_PACKET_SIZE, MAX_MESSAGE_HANDLERS>::se
 {
     MessageHandlerType fp;
     fp.attach(mh);
-    setMessageHandler(topicFilter, fp);
+    return setMessageHandler(topicFilter, fp);
 }
 
 template<class Network, class Timer, int MAX_MQTT_PACKET_SIZE, int MAX_MESSAGE_HANDLERS>


### PR DESCRIPTION
`return` statement was missing from `setMessageHandler` overload accepting raw function pointer which was reported as warning.